### PR TITLE
Websocket replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 package-lock.json
 .nyc_output/
 .dat/
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ const url = `ws://localhost:3000/${key}`
 
 const archive = hyperdrive('./somewhere', key)
 
-const socket = websocket(url)
+archive.once('ready', () => {
+  const socket = websocket(url)
 
-// Replicate through the socket
-socket.pipe(archive.replicate()).pipe(socket)
-
+  // Replicate through the socket
+  socket.pipe(archive.replicate()).pipe(socket)
+})
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ http://localhost:3000/garbados.hashbase.io/icons/favicon.ico
 
 The gateway will peer archives until they expire from the cache, at which point it proactively halts them and deletes them from disk.
 
+The gateway also supports replicating a hyperdrive instance using [websockets](https://github.com/maxogden/websocket-stream)
+
+```javascript
+const Websocket = require('websocket-stream')
+const hyperdrive = require('hyperdrive')
+
+const key = 'c33bc8d7c32a6e905905efdbf21efea9ff23b00d1c3ee9aea80092eaba6c4957'
+const url = `ws://localhost:3000/${key}`
+
+const archive = hyperdrive('./somewhere', key)
+
+const socket = websocket(url)
+
+// Replicate through the socket
+socket.pipe(archive.replicate()).pipe(socket)
+
+```
+
 ## Contributions
 
 All contributions are welcome: bug reports, feature requests, "why doesn't this work" questions, patches for fixes and features, etc. For all of the above, [file an issue](https://github.com/garbados/dat-gateway/issues) or [submit a pull request](https://github.com/garbados/dat-gateway/pulls).

--- a/index.js
+++ b/index.js
@@ -105,7 +105,9 @@ class DatGateway extends DatLibrarian {
 
       return this.add(address).then((dat) => {
         const archive = dat.archive
-        stream.pipe(archive.replicate()).pipe(stream)
+        stream.pipe(archive.replicate({
+          live: true
+        })).pipe(stream)
       }).catch((e) => {
         stream.end(e.message)
       })

--- a/index.js
+++ b/index.js
@@ -47,11 +47,11 @@ class DatGateway extends DatLibrarian {
     return this.getHandler().then((handler) => {
       log('Setting up server...')
       this.server = http.createServer(handler)
-      const websocketHandler = this.getWebsocketHandler();
+      const websocketHandler = this.getWebsocketHandler()
       this.websocketServer = Websocket.createServer({
         perMessageDeflate: false,
         server: this.server
-      }, websocketHandler);
+      }, websocketHandler)
     }).then(() => {
       log('Loading pre-existing archives...')
       // load pre-existing archives
@@ -96,7 +96,7 @@ class DatGateway extends DatLibrarian {
   getWebsocketHandler () {
     return (stream, req) => {
       const urlParts = req.url.split('/')
-      const address = urlParts[1];
+      const address = urlParts[1]
 
       if (!address) {
         stream.end('Must provide archive key')
@@ -104,11 +104,11 @@ class DatGateway extends DatLibrarian {
       }
 
       return this.add(address).then((dat) => {
-        const archive = dat.archive;
-        stream.pipe(archive.replicate()).pipe(stream);
+        const archive = dat.archive
+        stream.pipe(archive.replicate()).pipe(stream)
       }).catch((e) => {
-        stream.end(e.message);
-      });
+        stream.end(e.message)
+      })
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports =
 class DatGateway extends DatLibrarian {
   constructor ({ dir, dat, max, net, period, ttl }) {
     dat = dat || {}
-    dat.temp = dat.temp || true // store dats in memory only
+    if (typeof dat.temp === 'undefined') {
+      dat.temp = dat.temp || true // store dats in memory only
+    }
     super({ dir, dat, net })
     this.max = max
     this.ttl = ttl

--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ class DatGateway extends DatLibrarian {
   getHandler () {
     return this.getIndexHtml().then((welcome) => {
       return (req, res) => {
+        res.setHeader('Access-Control-Allow-Origin', '*')
         const start = Date.now()
         // TODO redirect /:key to /:key/
         let urlParts = req.url.split('/')
@@ -126,7 +127,7 @@ class DatGateway extends DatLibrarian {
         // return index
         if (!address && !path) {
           res.writeHead(200)
-          res.end(welcome)
+          res.end('dat-gateway')
           return Promise.resolve()
         }
         // return the archive

--- a/index.js
+++ b/index.js
@@ -107,7 +107,11 @@ class DatGateway extends DatLibrarian {
         Object.keys(this.dats).forEach((key) => {
           let dat = this.dats[key]
           let connections = dat.network.connections.length
-          stream.write(key + ':' + connections)
+          try {
+            stream.write(key + ':' + connections)
+          } catch (e) {
+            console.log('Error with websocket: ' + e)
+          }
         })
       } else {
         return this.add(address).then((dat) => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "dependency-check": "^2.9.1",
     "mocha": "^5.0.0",
+    "random-access-memory": "^2.4.0",
     "rimraf": "^2.6.2",
     "standard": "^10.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "dat-librarian": "^1.1.2-alpha",
     "hyperdrive-http": "^4.2.2",
+    "websocket-stream": "^5.1.2",
     "yargs": "^11.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -4,6 +4,9 @@ const assert = require('assert')
 const http = require('http')
 const DatGateway = require('.')
 const rimraf = require('rimraf')
+const hyperdrive = require('hyperdrive')
+const websocket = require('websocket-stream')
+const ram = require('random-access-memory')
 
 const dir = 'fixtures'
 const ttl = 4000
@@ -63,6 +66,33 @@ describe('dat-gateway', function () {
           return resolve()
         }
       }, ttl)
+    })
+  })
+
+  it('should handle websockets for replication', function () {
+    // Key for gardos.hashbase.io
+    const key = 'c33bc8d7c32a6e905905efdbf21efea9ff23b00d1c3ee9aea80092eaba6c4957'
+
+    const url = `ws://localhost:5917/${key}`
+
+    const archive = hyperdrive(ram, key)
+    const socket = websocket(url)
+
+    socket.pipe(archive.replicate()).pipe(socket)
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        archive.readFile('/icons/favicon.ico', (e, content) => {
+          if (e) reject(e)
+          else resolve(content)
+        })
+      }, 3000)
+    }).then((content) => {
+      socket.end()
+    }, (e) => {
+      socket.end()
+      console.error(e.message)
+      throw e
     })
   })
 })


### PR DESCRIPTION
This adds a websocket server which listens on `locahost:3000/:daturlhere` and creates a replication stream for the hyperdrive archive.

The purpose is to enable browsers to not only view dat content, but to also be able to load entire dat archives or publish their own archives (for instance updates) to the network.

The long term goal is to enable the DatArchive API in [browsers](https://github.com/sammacbeth/dat-fox/issues/1).