### PR TITLE
fix: handler now redirects /:key -> /:key/

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,12 +136,21 @@ class DatGateway extends DatLibrarian {
   getHandler () {
     return this.getIndexHtml().then((welcome) => {
       return (req, res) => {
-        res.setHeader('Access-Control-Allow-Origin', '*')
         const start = Date.now()
         // TODO redirect /:key to /:key/
         let requestURL = `http://${req.headers.host}${req.url}`
         let urlParts = url.parse(requestURL)
         let pathParts = urlParts.pathname.split('/').slice(1)
+        if (pathParts.length === 1) {
+          // redirect
+          res.writeHead(302, {
+            'Access-Control-Allow-Origin': '*',
+            'Location': `${req.url}/`
+          })
+          return res.end()
+        } else {
+          res.setHeader('Access-Control-Allow-Origin', '*')
+        }
         let hostnameParts = urlParts.hostname.split('.')
 
         let subdomain = hostnameParts[0]

--- a/test.js
+++ b/test.js
@@ -47,10 +47,22 @@ describe('dat-gateway', function () {
 
   it('should handle requests for dead addresses', function () {
     return new Promise((resolve) => {
-      http.get('http://localhost:5917/af75142d92dd1e456cf2a7e58a37f891fe42a1e49ce2a5a7859de938e38f4642', resolve)
+      http.get('http://localhost:5917/af75142d92dd1e456cf2a7e58a37f891fe42a1e49ce2a5a7859de938e38f4642/', resolve)
     }).then((res) => {
       // show blank index
       assert.equal(res.statusCode, 200)
+    }).catch((e) => {
+      console.error(e)
+      throw e
+    })
+  })
+
+  it('should redirect requests without a trailing slash', function () {
+    return new Promise((resolve) => {
+      http.get('http://localhost:5917/af75142d92dd1e456cf2a7e58a37f891fe42a1e49ce2a5a7859de938e38f4642', resolve)
+    }).then((res) => {
+      // show blank index
+      assert.equal(res.statusCode, 302)
     }).catch((e) => {
       console.error(e)
       throw e


### PR DESCRIPTION
The server will now appropriately redirect requests that provide a key without a trailing slash. Some applications require the trailing slash in order to function properly.