### PR TITLE
Switch to sparse mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ module.exports =
 class DatGateway extends DatLibrarian {
   constructor ({ dir, dat, max, net, period, ttl, redirect }) {
     dat = dat || {}
-    dat.sparse = true // only download files requested by the user
+    if (typeof dat.sparse === 'undefined') {
+      dat.sparse = dat.sparse || true // only download files requested by the user
+    }
     if (typeof dat.temp === 'undefined') {
       dat.temp = dat.temp || true // store dats in memory only
     }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports =
 class DatGateway extends DatLibrarian {
   constructor ({ dir, dat, max, net, period, ttl, redirect }) {
     dat = dat || {}
+    dat.sparse = true // only download files requested by the user
     if (typeof dat.temp === 'undefined') {
       dat.temp = dat.temp || true // store dats in memory only
     }


### PR DESCRIPTION
Use [sparse mode](https://docs.datproject.org/docs/faq#what-if-i-don-t-want-to-download-all-the-data-does-dat-have-an-index) and only download files requested by the user.

Dat archives can be enormous and it’s pointless to download potential terrabytes of archive data if the user is only interested in `readme.txt` or `new-blog-posts.atom`.