### PR TITLE
Move cache to ~/.cache/dat-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Options:
   --host, -l      Host or ip for the gateway to listen on.  [default: "0.0.0.0"]
   --port, -p      Port for the gateway to listen on.             [default: 3000]
   --dir, -d       Directory to use as a cache.
-                                            [string] [default: "~/.dat-gateway"]
+                                      [string] [default: "~/.cache/dat-gateway"]
   --max, -m       Maximum number of archives allowed in the cache. [default: 20]
   --period        Number of milliseconds between cleaning the cache of expired
                   archives.                                     [default: 60000]

--- a/bin.js
+++ b/bin.js
@@ -4,6 +4,8 @@
 
 const DatGateway = require('.')
 const os = require('os')
+const path = require('path')
+const basedir = require('xdg').basedir
 const mkdirp = require('mkdirp')
 const pkg = require('./package.json')
 
@@ -30,7 +32,7 @@ require('yargs')
           coerce: function (value) {
             return value.replace('~', os.homedir())
           },
-          default: '~/.dat-gateway',
+          default: path.join(basedir.cacheHome(), 'dat-gateway'),
           normalize: true
         },
         max: {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "hyperdrive-http": "^4.3.4",
     "hex-to-32": "^2.0.0",
     "websocket-stream": "^5.1.2",
+    "xdg": "^0.1.1",
     "yargs": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It’s a cache directory containing nothing but ephemeral data. It belongs in the $XDG_CACHE_HOME directory (~/.cache) and not $HOME.