### PR TITLE
req handler: pass query string to hyperdrive-http

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,8 @@ class DatGateway extends DatLibrarian {
           // handle it!!
           const end = Date.now()
           log('[%s] %s %s | OK [%i ms]', address, req.method, path, end - start)
-          req.url = `/${path}`
+          var query = req.url.split('?')[1] || ''
+          req.url = `/${path}?${query}`
           dat.onrequest(req, res)
         }).catch((e) => {
           const end = Date.now()


### PR DESCRIPTION
The hyperdrive-http logic requires the wait= argument from the client
to determine wether the dat has been updated since the client last
got the data.

Fixes infinite refresh: fix #18.