### PR TITLE
feat: configurable dat port

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Options:
   --config        Path to JSON config file
   --host, -l      Host or ip for the gateway to listen on.  [default: "0.0.0.0"]
   --port, -p      Port for the gateway to listen on.             [default: 3000]
+  --dat-port, -P  Port for Dat to listen on. Defaults to Dat's internal
+                  defaults.                                      [default: null]
   --dir, -d       Directory to use as a cache.
                                       [string] [default: "~/.cache/dat-gateway"]
   --max, -m       Maximum number of archives allowed in the cache. [default: 20]
@@ -52,6 +54,8 @@ Options:
   --ttl, -t       Number of milliseconds before archives expire.
                                                                [default: 600000]
   --redirect, -r  Whether to use subdomain redirects            [default: false]
+  --loopback, -L  What hostname to use when serving locally.
+                                                      [default: "dat.localhost"]
   -h, --help      Show help                                            [boolean]
 ```
 

--- a/bin.js
+++ b/bin.js
@@ -26,6 +26,11 @@ require('yargs')
           description: 'Port for the gateway to listen on.',
           default: 3000
         },
+        'dat-port': {
+          alias: 'P',
+          description: 'Port for Dat to listen on. Defaults to Dat\'s internal defaults.',
+          default: null
+        },
         dir: {
           alias: 'd',
           description: 'Directory to use as a cache.',
@@ -62,8 +67,11 @@ require('yargs')
       })
     },
     handler: function (argv) {
-      const { host, port, dir, ...gatewayOpts } = argv
+      const { host, port, dir, 'dat-port': datPort, ...gatewayOpts } = argv
       mkdirp.sync(dir) // make sure it exists
+      if (datPort) {
+        gatewayOpts.dat = { port: datPort }
+      }
       const gateway = new DatGateway({ dir, ...gatewayOpts })
       gateway
         .load()


### PR DESCRIPTION
This PR closes https://github.com/garbados/dat-gateway/issues/17 by adding a `-P, --dat-port` option to set Dat's port. This is passed directly through to Dat.